### PR TITLE
Implement core health sync and debt computation with basic UI

### DIFF
--- a/Sleep Debt/AppState.swift
+++ b/Sleep Debt/AppState.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Observation
+import SwiftData
+
+@Observable class AppState {
+    private let container: ModelContainer
+    private let debtEngine: DebtEngine
+
+    var headlineDebtMinutes: Int = 0
+    var debtLabel: String? = nil
+    var lastSync: Date? = nil
+    var chartPoints: [ChartPoint] = []
+    var todaySummary: DailySummary?
+
+    init(container: ModelContainer) {
+        self.container = container
+        self.debtEngine = DebtEngine(container: container)
+    }
+
+    func refresh() {
+        Task {
+            self.headlineDebtMinutes = (try? debtEngine.computeDebt14()) ?? 0
+            self.chartPoints = (try? debtEngine.buildChartPoints(windowDays: 30)) ?? []
+        }
+    }
+}

--- a/Sleep Debt/ContentView.swift
+++ b/Sleep Debt/ContentView.swift
@@ -9,11 +9,18 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Sleep Debt")
-            .padding()
+        TabView {
+            NavigationStack { HomeView() }
+                .tabItem { Label("Home", systemImage: "house.fill") }
+            NavigationStack { DetailsView() }
+                .tabItem { Label("Details", systemImage: "list.bullet") }
+            NavigationStack { SettingsView() }
+                .tabItem { Label("Settings", systemImage: "gearshape") }
+        }
     }
 }
 
 #Preview {
     ContentView()
+        .environment(AppState(container: try! ModelContainer(for: SleepDebtSchemaV1.self)))
 }

--- a/Sleep Debt/DebtEngine.swift
+++ b/Sleep Debt/DebtEngine.swift
@@ -1,0 +1,79 @@
+import Foundation
+import SwiftData
+
+struct ChartPoint {
+    let date: Date
+    let debtMinutes: Int
+}
+
+final class DebtEngine {
+    private let container: ModelContainer
+
+    init(container: ModelContainer) {
+        self.container = container
+    }
+
+    /// Aggregate a day into DailySummary based on stored episodes
+    func aggregateDay(dayId: String) throws -> DailySummary? {
+        let context = ModelContext(container)
+        let request = FetchDescriptor<SleepEpisode>(predicate: #Predicate { $0.anchoredDayId == dayId })
+        let episodes = try context.fetch(request)
+        guard !episodes.isEmpty else { return nil }
+        let actualMinutes = episodes.reduce(0) { $0 + Int($1.end.timeIntervalSince($1.start) / 60) }
+        let settings = try context.fetch(FetchDescriptor<UserSettings>()).first ?? UserSettings()
+        let delta = settings.goalMinutes - actualMinutes
+        let summary = DailySummary(dayId: dayId,
+                                   date: episodes.first!.start,
+                                   hasData: true,
+                                   actualMinutes: actualMinutes,
+                                   deltaMinutes: delta,
+                                   cumulativeDebtMinutes: 0,
+                                   dataQuality: .complete,
+                                   sourceCount: Set(episodes.map { $0.sourceBundleId }).count)
+        context.insert(summary)
+        try context.save()
+        return summary
+    }
+
+    /// Rebuild cumulative debt from a starting dayId backwards
+    func rebuildFrom(dayId: String, lookbackDays: Int = 32) throws {
+        let context = ModelContext(container)
+        let fetch = FetchDescriptor<DailySummary>(sortBy: [SortDescriptor(\.date)])
+        var summaries = try context.fetch(fetch)
+        summaries.sort { $0.date < $1.date }
+        var prevDebt = 0
+        for summary in summaries {
+            summary.cumulativeDebtMinutes = max(0, prevDebt + summary.deltaMinutes)
+            prevDebt = summary.cumulativeDebtMinutes
+        }
+        try context.save()
+    }
+
+    /// Compute 14-day debt from last 14 days with data
+    func computeDebt14(asOf date: Date = .now) throws -> Int {
+        let context = ModelContext(container)
+        let calendar = Calendar.current
+        guard let start = calendar.date(byAdding: .day, value: -13, to: date) else { return 0 }
+        let predicate = #Predicate<DailySummary> { summary in
+            summary.date >= start && summary.date <= date && summary.hasData
+        }
+        let fetch = FetchDescriptor<DailySummary>(predicate: predicate)
+        let summaries = try context.fetch(fetch)
+        return summaries.reduce(0) { $0 + $1.deltaMinutes }
+    }
+
+    func buildChartPoints(windowDays: Int) throws -> [ChartPoint] {
+        let context = ModelContext(container)
+        let calendar = Calendar.current
+        guard let start = calendar.date(byAdding: .day, value: -windowDays + 1, to: .now) else { return [] }
+        let predicate = #Predicate<DailySummary> { $0.date >= start }
+        let fetch = FetchDescriptor<DailySummary>(predicate: predicate, sortBy: [SortDescriptor(\.date)])
+        let summaries = try context.fetch(fetch)
+        return summaries.map { ChartPoint(date: $0.date, debtMinutes: $0.cumulativeDebtMinutes) }
+    }
+
+    func computeBaselineLabel(asOf date: Date = .now) throws -> String? {
+        // Placeholder baseline: return nil for now
+        return nil
+    }
+}

--- a/Sleep Debt/DetailsView.swift
+++ b/Sleep Debt/DetailsView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct DetailsView: View {
+    @Environment(AppState.self) private var appState
+    @State private var range: Int = 14
+
+    var body: some View {
+        VStack {
+            Picker("Range", selection: $range) {
+                Text("7").tag(7)
+                Text("14").tag(14)
+                Text("30").tag(30)
+                Text("60").tag(60)
+                Text("90").tag(90)
+            }
+            .pickerStyle(.segmented)
+            List {
+                ForEach(appState.chartPoints, id: \.date) { point in
+                    HStack {
+                        Text(point.date, style: .date)
+                        Spacer()
+                        Text("\(point.debtMinutes) min")
+                    }
+                }
+            }
+        }
+        .padding()
+        .onAppear { appState.refresh() }
+    }
+}
+
+#Preview {
+    DetailsView()
+        .environment(AppState(container: try! ModelContainer(for: SleepDebtSchemaV1.self)))
+}

--- a/Sleep Debt/HealthStoreManager.swift
+++ b/Sleep Debt/HealthStoreManager.swift
@@ -1,0 +1,54 @@
+import Foundation
+import HealthKit
+
+actor HealthStoreManager {
+    private let healthStore = HKHealthStore()
+
+    func requestAuthorization() async throws {
+        let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
+        try await healthStore.requestAuthorization(toShare: [], read: [sleepType])
+    }
+
+    func enableBackgroundDelivery() async throws {
+        let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
+        try await healthStore.enableBackgroundDelivery(for: sleepType, frequency: .immediate)
+    }
+
+    func startObservers() async throws {
+        let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
+        let query = HKObserverQuery(sampleType: sleepType, predicate: nil) { [weak self] _, completion, error in
+            guard error == nil else {
+                completion()
+                return
+            }
+            Task {
+                _ = try? await self?.runAnchoredFetch()
+                completion()
+            }
+        }
+        healthStore.execute(query)
+    }
+
+    func runAnchoredFetch(anchor: HKQueryAnchor? = nil) async throws -> FetchResult {
+        let sleepType = HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!
+        return try await withCheckedThrowingContinuation { continuation in
+            let query = HKAnchoredObjectQuery(type: sleepType, predicate: nil, anchor: anchor, limit: HKObjectQueryNoLimit) { _, samplesOrNil, deletedOrNil, newAnchor, error in
+                if let error = error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let samples = samplesOrNil as? [HKCategorySample] ?? []
+                let deleted = deletedOrNil ?? []
+                let result = FetchResult(added: samples, deleted: deleted, newAnchor: newAnchor)
+                continuation.resume(returning: result)
+            }
+            healthStore.execute(query)
+        }
+    }
+}
+
+struct FetchResult {
+    let added: [HKCategorySample]
+    let deleted: [HKDeletedObject]
+    let newAnchor: HKQueryAnchor
+}

--- a/Sleep Debt/HomeView.swift
+++ b/Sleep Debt/HomeView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import Charts
+
+struct HomeView: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("\(formatMinutes(appState.headlineDebtMinutes))")
+                .font(.system(size: 48, weight: .bold))
+            if let label = appState.debtLabel {
+                Text(label)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            if let lastSync = appState.lastSync {
+                Text("Last sync: \(lastSync, style: .time)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Chart(appState.chartPoints, id: \.date) { point in
+                LineMark(x: .value("Date", point.date), y: .value("Debt", point.debtMinutes))
+            }
+            .frame(height: 200)
+            Spacer()
+        }
+        .padding()
+        .onAppear { appState.refresh() }
+    }
+
+    private func formatMinutes(_ minutes: Int) -> String {
+        let hours = minutes / 60
+        let mins = minutes % 60
+        return "\(hours)h \(mins)m"
+    }
+}
+
+#Preview {
+    HomeView()
+        .environment(AppState(container: try! ModelContainer(for: SleepDebtSchemaV1.self)))
+}

--- a/Sleep Debt/Normalization.swift
+++ b/Sleep Debt/Normalization.swift
@@ -1,0 +1,82 @@
+import Foundation
+import HealthKit
+
+struct Interval {
+    let start: Date
+    let end: Date
+    let sourceId: String
+}
+
+/// Accepts only asleep samples
+func filterAsleep(_ samples: [HKCategorySample]) -> [Interval] {
+    samples.compactMap { sample in
+        switch HKCategoryValueSleepAnalysis(rawValue: sample.value) {
+        case .asleepCore?, .asleepDeep?, .asleepREM?, .asleepUnspecified?:
+            return Interval(start: sample.startDate, end: sample.endDate, sourceId: sample.sourceRevision.source.bundleIdentifier)
+        default:
+            return nil
+        }
+    }
+}
+
+/// Merge overlapping intervals and coalesce small gaps
+func mergeAndCoalesce(_ intervals: [Interval], gapSeconds: Int = 120) -> [Interval] {
+    guard !intervals.isEmpty else { return [] }
+    let sorted = intervals.sorted { $0.start < $1.start }
+    var result: [Interval] = []
+    var current = sorted[0]
+    for interval in sorted.dropFirst() {
+        if interval.start.timeIntervalSince(current.end) <= TimeInterval(gapSeconds) {
+            let newEnd = max(current.end, interval.end)
+            current = Interval(start: current.start, end: newEnd, sourceId: current.sourceId)
+        } else {
+            result.append(current)
+            current = interval
+        }
+    }
+    result.append(current)
+    return result
+}
+
+/// Split intervals by boundary hour and tag with dayId
+struct IntervalSegment {
+    let dayId: String
+    let start: Date
+    let end: Date
+    let sourceId: String
+}
+
+func splitByBoundary(_ intervals: [Interval], boundaryHour: Int, timeZone: TimeZone = .current) -> [IntervalSegment] {
+    var segments: [IntervalSegment] = []
+    let calendar = Calendar.current
+    for interval in intervals {
+        var cursorStart = interval.start
+        while cursorStart < interval.end {
+            let dayComponents = calendar.dateComponents(in: timeZone, from: cursorStart)
+            var boundaryComponents = DateComponents()
+            boundaryComponents.year = dayComponents.year
+            boundaryComponents.month = dayComponents.month
+            boundaryComponents.day = dayComponents.day
+            boundaryComponents.hour = boundaryHour
+            boundaryComponents.minute = 0
+            boundaryComponents.second = 0
+            guard let boundary = calendar.date(from: boundaryComponents) else { break }
+            let nextBoundary = calendar.date(byAdding: .day, value: 1, to: boundary)!
+            let segmentEnd = min(interval.end, nextBoundary)
+            let dayString = DateFormatter.dayFormatter.string(from: boundary)
+            let dayId = "\(dayString)@anchor\(boundaryHour)"
+            segments.append(IntervalSegment(dayId: dayId, start: cursorStart, end: segmentEnd, sourceId: interval.sourceId))
+            cursorStart = segmentEnd
+        }
+    }
+    return segments
+}
+
+private extension DateFormatter {
+    static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}

--- a/Sleep Debt/SettingsView.swift
+++ b/Sleep Debt/SettingsView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+import SwiftData
+
+struct SettingsView: View {
+    @Environment(AppState.self) private var appState
+    @Query private var settings: [UserSettings]
+
+    var body: some View {
+        if let setting = settings.first {
+            Form {
+                Stepper(value: binding(for: \.goalMinutes, in: setting), step: 15, in: 240...720) {
+                    Text("Sleep goal: \(setting.goalMinutes) min")
+                }
+                Stepper(value: binding(for: \.dayBoundaryHour, in: setting), in: 0...12) {
+                    Text("Day boundary: \(setting.dayBoundaryHour):00")
+                }
+            }
+        } else {
+            Text("No settings")
+        }
+    }
+
+    private func binding<T>(for keyPath: WritableKeyPath<UserSettings, T>, in object: UserSettings) -> Binding<T> {
+        Binding(get: { object[keyPath: keyPath] }, set: { object[keyPath: keyPath] = $0 })
+    }
+}
+
+#Preview {
+    SettingsView()
+        .environment(AppState(container: try! ModelContainer(for: SleepDebtSchemaV1.self)))
+}

--- a/Sleep Debt/Sleep_DebtApp.swift
+++ b/Sleep Debt/Sleep_DebtApp.swift
@@ -10,20 +10,26 @@ import SwiftData
 
 @main
 struct Sleep_DebtApp: App {
-    var sharedModelContainer: ModelContainer = {
+    let sharedModelContainer: ModelContainer
+    @State private var appState: AppState
+
+    init() {
         let config = ModelConfiguration(migrationPlan: SleepDebtMigrationPlan.self,
                                         isStoredInMemoryOnly: false)
         do {
-            return try ModelContainer(for: SleepDebtSchemaV1.self,
-                                      configurations: [config])
+            let container = try ModelContainer(for: SleepDebtSchemaV1.self,
+                                               configurations: [config])
+            self.sharedModelContainer = container
+            _appState = State(initialValue: AppState(container: container))
         } catch {
             fatalError("Could not create ModelContainer: \(error)")
         }
-    }()
+    }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(appState)
         }
         .modelContainer(sharedModelContainer)
     }


### PR DESCRIPTION
## Summary
- add `HealthStoreManager` actor to authorize HealthKit, observe sleep data and perform anchored fetches
- normalize sleep samples into segments and build debt aggregation with `DebtEngine`
- create `AppState` and basic Home, Details and Settings views with environment injection

## Testing
- `xcodebuild -list` *(fails: command not found)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6898a34618608324ace79852e552282f